### PR TITLE
feat(vpc): Use Existing VPC Instead of Creating New Ones

### DIFF
--- a/infrastructure/vpc.ts
+++ b/infrastructure/vpc.ts
@@ -9,27 +9,36 @@ import { Construct } from 'constructs';
  * - Maintains high availability across 2 AZs
  */
 export class PaymentServiceVPC extends Construct {
-  public readonly vpc: ec2.Vpc;
+  public readonly vpc: ec2.IVpc;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    this.vpc = new ec2.Vpc(this, 'PaymentServiceVPC', {
-      maxAzs: 2,
-      ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/24'), // Smaller CIDR range
-      subnetConfiguration: [
-        {
-          cidrMask: 27, // 32 IPs per subnet
-          name: 'Public',
-          subnetType: ec2.SubnetType.PUBLIC,
-        },
-        {
-          cidrMask: 27, // 32 IPs per subnet
-          name: 'Private',
-          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-        },
-      ],
-      natGateways: 1, // Reduce to 1 NAT Gateway to save costs
+    // Try to get an existing VPC by name
+    this.vpc = ec2.Vpc.fromLookup(this, 'ExistingVPC', {
+      isDefault: false, // Ensure it's not the default VPC
+      vpcName: 'PaymentServiceSharedVPC',
     });
+
+    if (!this.vpc) {
+      this.vpc = new ec2.Vpc(this, 'PaymentServiceVPC', {
+        vpcName: 'PaymentServiceSharedVPC',
+        maxAzs: 2,
+        ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/24'), // Smaller CIDR range
+        subnetConfiguration: [
+          {
+            cidrMask: 27, // 32 IPs per subnet
+            name: 'Public',
+            subnetType: ec2.SubnetType.PUBLIC,
+          },
+          {
+            cidrMask: 27, // 32 IPs per subnet
+            name: 'Private',
+            subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          },
+        ],
+        natGateways: 1, // Reduce to 1 NAT Gateway to save costs
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR updates the CDK script to prevent exceeding the AWS VPC limit by reusing an existing VPC instead of creating a new one on every deployment.

